### PR TITLE
created a workaround for missing data fields, added comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
                 </div>
                 <div id="desks">
-                    <div id="main-buttons">
+                    <div id="main-buttons" style="display: block;">
                         <div id="nav-buttons">National</div>
                         <div id="nav-buttons">Foreign</div>
                         <div id="nav-buttons">Metropolitan</div>
@@ -32,6 +32,14 @@
                         <div id="nav-buttons">Week In Review</div>
                         <div id="nav-buttons">Travel</div>
                         <div id="nav-buttons">Home</div>
+                    </div>
+                    <div id="disclaimer" style="display: none;">
+                        <div>
+                            <p>The articles for this date are unsortable, if you would like to see the articles anyway click on the button below</p>
+                        </div>
+                        <div id="noneButton">
+                            All Articles
+                        </div>
                     </div>
                 </div>
 
@@ -60,7 +68,7 @@
             <input type="text" id="movieName" title="Put the name of your favorite movie in here" placeholder="Enter the name of your favorite movie here">
             <button id="searchButton">Search</button>
         </div>
-        <div class="movieList">
+        <div id="movieList">
 
         </div>
         <div class="news"></div>

--- a/script.js
+++ b/script.js
@@ -1,54 +1,73 @@
 //VARIABLESxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 var mainInput = $("#movieName")
-var movieListEl = $(".movieList");
+var movieListEl = $("#movieList");
 var searchButton = $("#searchButton");
 var modalDesksEl = $("#desks");
 var modalButtonsEl = $("#main-buttons");
 var modalArticlesEl = $("#article-links");
 var modalCloseButton = $("#close-button");
 var modalMainEl = $("#main-modal");
+var disclaimerEL = $("#disclaimer")
+var noneButton = $("#noneButton")
 var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 var monthsNum = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11","12"];
 var oldDate
 var articles = [];
+var articlesN = [];
 var varName = 0;
+var nSignal = 0
+
 
 
 //FUNCTIONSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-function getNews(){
-    var queryURL = "http://www.omdbapi.com/?apikey=347e88dd&s=" + movieName;
-    $.ajax({
-        url: queryURL,
-        method: "GET"
-    }).then(function(response){
-        });
-}
 
+
+
+//THIS FUNCTION DISPLAYS THE SEARCH RESULT AND CALLS THE FUNCTION THAT ARRANGES THE RESULTS IN A USER FREINDLY WAY
+//IT ALSO RETURNS "NO RESULTS FOUND" IF IT CAN'T FIND A MOVIE TITLE
 function movieSearch(){
+    //Clears the results before every search+++++
     if(movieListEl.children()){
         movieListEl.children().remove()
     }
+    //Makes the API query+++++++++++++++++++++++
     var searchName = $("#movieName").val();
     var queryURL = "http://www.omdbapi.com/?apikey=347e88dd&type=movie&s=" + searchName;
     $.ajax({
         url: queryURL,
         method: "GET"
     })
+    //Calls the functions that create the result and checks to see if the search returned a valid response++++++
     .then(function(response){
-        response.Search.forEach(element => {
-        movieList(element)       
+        if(response.Response === "True")
+            response.Search.forEach(element => {
+                movieList(element)
+            })  
+        else{
+            movieNone()    
+        }  
     });
-    })
-    
 }
 
+//THIS FUNCTION CREATES THE ELEMENTS OF THE "RESULTS NOT FOUND" RESPONSE AND APPENDS THEM TO THE DOM
+function movieNone(){
+    var container = $("<div>");  //==========================CSS
+    var titleH2 = $("<h2>")      //==========================CSS
+    titleH2.text("No Results Found")
+    container.append(titleH2)
+    movieListEl.append(container)
+}
+
+//THIS FUNCTION CREATES THE ELEMENTS THAT RENDER THE MOVIE TITLES AND POSTERS AND APPENDS THEM TO THE DOM
 function movieList(e){
-    var container = $("<div>");
-    var title = $("<div>");
-    var poster = $("<div>");
-    var titleH2 = $("<h2>");
-    var year = $("<h2>");
-    var posterIMG = $("<img>");
+    //Creates elements+++++++++++++
+    var container = $("<div>");         
+    var title = $("<div>");             
+    var poster = $("<div>");            
+    var titleH2 = $("<h2>");            
+    var year = $("<h2>");               
+    var posterIMG = $("<img>");         
+    //Sets element attributes++++++++++++++++++++++++++++++++++CSS
     container.attr("style", "display:flex; margin-bottom:1vw;");
     posterIMG.attr("id", "poster");
     title.attr("style", "margin-right:1vw; word-wrap:break-word; width:25%");
@@ -56,26 +75,26 @@ function movieList(e){
         posterIMG.attr("src", "https://via.placeholder.com/300x447?text=No+Image+Available")    
     }
     else{
-
         posterIMG.attr("src", e.Poster)
-        
     }
     posterIMG.attr("data-year", e.Year)
     posterIMG.attr("data-title", e.Title)
+    //Sets text values+++++++++++++++++++++++++++
     titleH2.text(e.Title);
     year.text(e.Year);
+    //Appends elements++++++++++++++++++++++++++
     title.append(titleH2);
     title.append(year);
     poster.append(posterIMG);
     container.append(title);
     container.append(poster);
     movieListEl.append(container);
-    
 }
 
+//THIS FUNCTION QUERIES THE MOVIE API FOR THE SPECIFIC MOVIE TITLE AND YEAR OF THE POSTER THAT IS CLICKED
+//IT ALSO UNHIDES THE MODAL WITH THE NEWS INFORMATION
 function getMovieInfo(event){
-    console.log(event.target)
-    // var movieName = $("#movieName").val();
+    //Queries the movie API+++++++++++++++++++++++++++++++++++
     var movieYear = $(event.target).attr("data-year")
     var movieName = $(event.target).attr("data-title")
     var queryURL = "http://www.omdbapi.com/?apikey=347e88dd&&t=" + movieName + "&y=" + movieYear ;
@@ -84,15 +103,17 @@ function getMovieInfo(event){
         method: "GET"
     })
     .then(function(response){
-        console.log(response)
         var released = response.Released;
         var splitDate = released.split(" ");
+        //Reformats date from movie API to a the porper format for the NYT query++++++++++++++
         dateConverter(splitDate)
-        
     });
+    //Displays modal+++++++++++++++++++++++++++++++++++++
     modalMainEl.attr("style", "display:flex")
 }
 
+//THIS FUNCTIONCONVERTS THE DATE OBTAINED FROM THE MOVIE API QUERY TO A SUITABLE FORMAT FOR THE NYT QUERY
+//IT ALSO CALLS THE FUNCTION THAT QUERIES THE NYT API
 function dateConverter(date){
     months.forEach(element =>{
         var i = months.indexOf(element)
@@ -100,17 +121,17 @@ function dateConverter(date){
         if(date[1] === months[i]){
             date.splice(1, 1, n)
         }
-        
-        
     })
     NYTData(date)
 
 }
 
+//THIS FUNCTION QUERIES THE NYT FOR NEWS ARTICLES PUBLISHED ON THE DATE OF THE RELEASE OF THE SELECTED MOVIE
+//IT ALSO REFORMATS THE DATE FROM THE INITIAL NYT QUERY TO SOMETHING MORE SUITABLE TO SEARCH THE ARTICLES THAT ARE RETURNED
+//IT ALSO CALLS THE FUNCTIONS THAT ORGANIZE AND EXTRACT THE RELEVANT DATA FROM THE NYT QUERY RESULTS BASED ON DATE AND NEWS DESK
+//IT ALSO CHECKS FOR EMPTY FIELDS IN THE NEWS_DESK FIELD OF THE ARTICLES AND CALLS THE FUNCTION TO VIEW THE UNORGANIZED FIELDS
 function NYTData(gdate){
-    // console.log(gdate[0]);
-    // console.log(gdate[1]);
-    // console.log(gdate[2]);
+    //Queries the NYT for articles from the month and year of the selected movie+++++++++++++++++++
     var newNums = ["1","2","3","4","5","6","7","8","9"]
     var queryURL = "https://api.nytimes.com/svc/archive/v1/" +gdate[2]+"/"+gdate[1]+".json?api-key=t7uEOJet36tmSbd8T0F47LNB1NcGTrAj";
     $.ajax({
@@ -118,33 +139,48 @@ function NYTData(gdate){
         method: "GET"
     })
     .then(function(res){
-        
+        //Check for date formating conflicts and resolves the conflicts by reformating the date information++++++
         newNums.forEach(elements=>{
             if(gdate[1] === elements){
                 queryToData(gdate)
                 NYTDate = "/"+ oldDate[2]+"/"+oldDate[1]+"/"+oldDate[0]
             }
             else{
-            NYTDate = "/"+ gdate[2]+"/"+gdate[1]+"/"+gdate[0]    
+                NYTDate = "/"+ gdate[2]+"/"+gdate[1]+"/"+gdate[0]    
             }
         })
         var NYTDate
-        console.log(gdate)
-        console.log(oldDate)
         var allDocs = res.response.docs
         articles = []
+        //Organizes and extracts the data and checks for missing fields
+        //If the data can't be organized it provides an unorganized option to view all the articles
         allDocs.forEach(element =>{
             if(element.web_url.includes(NYTDate)){
               articles.push(element)
-                console.log(element)
-                // console.log(element.web_url)
-                // console.log(element.news_desk)
             }
         })
-        NYTDataPull()
+        console.log(nSignal)
+        articles.forEach(element=>{
+            if(element.news_desk === "None"){
+                nSignal = 1
+            }
+            else{
+                nSignal = 0
+            }
+         })
+        if (nSignal === 1){
+            console.log("hi")
+            noneDesk()
+            nSignal = 0
+        }
+        else{
+            console.log("lo")
+            NYTDataPull()
+        }
     });
 }
 
+//THIS FUNCTION REFORMATS THE DATE FROM THE NYT QUERY TO A SUITABLE FORMAT TO SEARCH THROUGH THE DATA
 function queryToData(d){
     oldDate = d
     var newNums = ["1","2","3","4","5","6","7","8","9"]
@@ -154,54 +190,75 @@ function queryToData(d){
         }
     })
 }
-
-function NYTDataPull(){
-    modalButtonsEl.on("click", function(event){
-    var newsDesk = []    
+//THIS FUNCTION CALLS THE FUNCTION THAT CREATES AND APPENDS THE ELEMENTS THAT RENDER THE RELEVANT ARTICLES WHEN THEY CAN'T BE ORGANIZED
+//IT ALSO CLEARS ANY PREVIOUS DATA IN THE ARTICLES WINDOW IN THE MODAL
+//IT ALSO HIDES THE NEWS_DESK BUTTONS FROM THE MODAL NAVIGATION WINDOW AND SDISPLAYS THE "ARTICLE" BUTTON
+//IT ALSO CREATES THE EVENT LISTENER FOR THE "ARTICLES" BUTTON INSIDE THE MODAL
+function noneDesk(){
+    //Clears the information in the articles window+++++++++++++++++++++++++
     modalArticlesEl.children().remove()
-            articles.forEach(element=>{
-                if (element.news_desk.includes(event.target.innerHTML)){
-                    
-                    newsDesk.push()
-                    varName++
-                    var varName = $("<div>")
-                    var a = $("<a>")
-                    // var headP = $("<p>")
-                    var leadP = $("<p>")
-                    var idP = $("<p>")
-                    var link = $("<div>")
-                    // var headline = $("<div>")
-                    var leadPar = $("<div>")
-                    var articleId = $("<div>")
-                    a.attr("href", element.web_url)
-                    a.text(element.headline)
-                    leadP.text(element.lead_paragraph)
-                    idP.text(element._id)
-                    a.text(element.headline.main)
-                    link.append(a)
-                    leadPar.append(leadP)
-                    articleId.append(idP)
-                    varName.append(link, leadPar, articleId)
-                    modalArticlesEl.append(varName)
-                }
-                else{
-                    return
-                }
-            console.log(event.target.innerHTML)
-            console.log(event.target.id)
-
-            console.log(element.news_desk)
-            })
-        
-    })
-
-    modalCloseButton.on("click", function(event){
-        modalMainEl.attr("style", "display:none")
+    //Hides the New_Desk navigation buttons and displays the option to view th eunorganized articles+++++++++++
+    modalButtonsEl.attr("style", "display:none")
+    disclaimerEL.attr("style", "display:flex")
+    //Creates the event listener for the "Articles" button inside the modal 
+    noneButton.on("click", function(event){
+        articles.forEach(element=>{
+        //Calls the function that creates and appends the elements to render the articles
+            articleElements(element)
+        })
     })
 }
 
-//EVENT LISTENERSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+//THIS FUNCTION CALLS THE FUNCTION THAT CREATS AND APPENDS THE ELEMENTS THAT RENDER THE ORGANIZED ARTICLES IN THE MODAL WINDOW
+//IT ALSO CLEARS ANY PREVIOUS DATA IN THE ARTICLES WINDOW IN THE MODAL
+//IT ALSO HIDES THE "ARTICLES" BUTTON AND DISPLAYS THE "NEWS_DESK" BUTTONS
+//IT ALSO CREATES THE EVENT LISTENER FOR THE NAVIGATION BUTTONS IN THE MODAL
+function NYTDataPull(){
+    //Clears the article window in the modal+++++++++++++++++++++++++++++++++++
+    modalArticlesEl.children().remove()
+    //Hides the "Article" button and displays the "News_Desk" buttons++++++++++++++++++
+    modalButtonsEl.attr("style", "display:flex")
+    disclaimerEL.attr("style", "display:none")
+    //creates the event listener for the navigatioin buttons++++++++++++++++++
+    modalButtonsEl.on("click", function(event){
+        modalArticlesEl.children().remove()
+        //Organizes the data into "News_Desks"++++++++++++++++++++++++++++++
+        articles.forEach(element=>{
+            if (element.news_desk.includes(event.target.innerHTML)){
+                //Calls the function that creates and appends the elemets to render the articles+++++++++++
+               articleElements(element)
+            }
+        })
+    })
+}
 
+//THIS FUNCTION CREATES AND APPENDS THE ELEMENTS TO RENDER THE ARTICLES IN THE MODAL WINDOW
+function articleElements(element){
+    //Creates elements++++++++++++++++++++++++++++++++++++
+    var varName = $("<div>")
+    var a = $("<a>")
+    var leadP = $("<p>")
+    var idP = $("<p>")
+    var link = $("<div>")
+    var leadPar = $("<div>")
+    var articleId = $("<div>")
+    //Sets attributes++++++++++++++++++++++++++++++++++++++++++++++++++++++CSS
+    a.attr("target", "_blank")
+    a.attr("href", element.web_url)
+    //Sets text values++++++++++++++++++++++++++++++++++++++++++
+    a.text(element.headline)
+    leadP.text(element.lead_paragraph)
+    idP.text(element._id)
+    a.text(element.headline.main)
+    //Appends elements+++++++++++++++++++++++++++++++++++++++++
+    link.append(a)
+    leadPar.append(leadP)
+    articleId.append(idP)
+    varName.append(link, leadPar, articleId)
+    modalArticlesEl.append(varName)
+}
+//EVENT LISTENERSxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+//THESE EVENT LISTENER TRIGGER THE MOVIE SEARCH========================
 searchButton.on("click", function(event){
 movieSearch()  
 }) 
@@ -211,8 +268,7 @@ mainInput.on("keyup", function(event){
     }
 }) 
 
-
-
+//THIS EVENT LISTENER TRIGGERS THE NYT QUERY===========================
 document.addEventListener("click", function(event){
     if(event.target.id != "poster"){
         return
@@ -221,56 +277,11 @@ document.addEventListener("click", function(event){
        getMovieInfo(event)
     }
 })
+//THIS EVENT LISTENER TRIGGERS THE CLOSING OF THE MODAL==================
+modalCloseButton.on("click", function(event){
+    modalMainEl.attr("style", "display:none")
+})
 
 
-
-
-// var tes = ["03", "1" , "1980"]
-// var newNums = ["1","2","3","4","5","6","7","8","9"]
-// newNums.forEach(elements =>{
-//     if (tes[1] === elements){
-//         tes.splice(1,1, "0"+elements)
-//         console.log(tes)
-//     }
-// })
-// console.log($(".inputMovie").children()[1]
-
-    // var nation = $("<div>")
-    // var foreign = $("<div>")
-    // var metro = $("<div>")
-    // var financial = $("<div>")
-    // var sports = $("<div>")
-    // var science = $("<div>")
-    // var weekend = $("<div>")
-    // var art =$("<div>")
-    // var culture = $("<div>")
-    // var book = $("<div>")
-    // var society = $("<div>")
-    // var style = $("<div>")
-    // var weekIn = $("<div>")
-    // var travel = $("<div>")
-    // var home = $("<div>")
-
-
-        // var elementNames = ["container", "title", "poster", "titleH2", "year", "posterIMG"]
-    // var elementList = ["<div>", "<div>", "<div>", "<h2>", "<h2>", "<img>"]
-    // elementNames.forEach(element=>{
-    //     var i = elementNames.indexOf(element)
-    //     var element = $(elementList[i])
-    // })
-
-
-    // function NYTDataElements(){
-        //     var desks = ["nation", "foreign", "metro", "financial", "sports", "science", "weekend", "art", "culture", "book", "society", " style", 
-        //                 "weekIn", "travel", "home"]
-        //     var pic = $("<div>")
-        //     var picIMG = 
-        //     modalDesks.append(pic)
-        //     desks.forEach(element=>{
-        //         var i = desks.indexOf(element)
-        //         var element = $("<div>")
-        //         element.text(desks[i])
-        //         modalDesks.append(element)
-        //     });
-        // }
+   
         

--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@
 #movieName{
     width: 15vw;
 }
-.movieList{
+#movieList{
     
     font-size: 1vw;
     font-weight: 600;
@@ -47,8 +47,10 @@ img:hover{
 .main-modal{
     display: none;
     width: 100%;
-    height: 95%;
+    height: 100%;
     justify-content: center;
+    
+
 }
 
 .newsmodal{
@@ -56,10 +58,10 @@ img:hover{
     justify-content: start;
     position: fixed;
     z-index: 1;
-    margin: 0vw 3vw 0vw 3vw;
+    margin: 0vh 3vw 3vh 3vw;
     width: 95%;
-    height: 100%;
-    overflow: auto;
+    height: 99%;
+    /* overflow: auto; */
     background-color: #0a265aaa;
 }
 
@@ -67,7 +69,7 @@ img:hover{
     margin: 1vw 1vw 1vw 1vw;
     background-color: #f5f5f5;
     width: 25%;
-    height: 100%;
+    height: 96%;
 }
 
 #content{
@@ -77,7 +79,7 @@ img:hover{
     margin: 1vw 1vw 1vw 0vw;
     background-color: #f5f5f5;
     width: 75%;
-    height: 100%;
+    height: 96%;
 }
 #close-button{
     position: absolute;
@@ -109,7 +111,7 @@ h3{
     height: 100%;
     align-items: flex-end;
 }
-#nav-buttons{
+#nav-buttons, #noneButton{
     text-align: center;
     padding-top: 0.55vw;
     width: 6vw;
@@ -123,8 +125,8 @@ h3{
     height: 33%;
     width: 100%;
 }
-
-/* #article-links{
-    overflow: scroll;
-    height: auto;
-} */
+ #disclaimer{
+     flex-direction: column;
+     justify-content: center;
+     align-content: center;
+ }


### PR DESCRIPTION
I made of few fixes and workarounds for some missing data fields in the NYT data, I wasn't able to work on the local storage part today but I will work on it tomorrow, I also added comments to the script.js file and added tags so that you can find where I am creating new elements and apply the css there.

If you are in the script.js file just do a search(ctrl+s) for CSS all in caps and you will see the tags, hope it helps, also hope I didn't break any of the css you already added, if I did then let me know and I can help you sort it out

There where some missing fields in the NYT data so I had to add some elements to the modal, you will see them in the HTML,
basically some of the older articles in the NYT database don't have News Desk so there is no way to sort them, I added an option to see the articles anyway as a giant list.

To see what I am talking about, search for the movie "top gun" then click on the Tom Cruise movie, you should see the layout I  showed you in class.
Then try clicking on the cowboy movie "Top Gun" and you should see a single "Articles" button and a disclaimer saying the articles can't be organized
It's all in the HTML I'm just using .js to hide and unhide the elements, hopefully that makes it easier to add css